### PR TITLE
Add back navigation behavior to arrow icons

### DIFF
--- a/robux_account_pc (done)/Component.html
+++ b/robux_account_pc (done)/Component.html
@@ -6,7 +6,7 @@
         <div class="div__div3">
           Укажите аккаунт, на который будут отправлены приобритенные робуксы
         </div>
-        <img class="div__frame-1000002526" src="frame-10000025260.svg" />
+        <img class="div__frame-1000002526" onclick="window.history.back()" src="frame-10000025260.svg" />
       </div>
       <div class="div__frame-1000005981">
         <div class="div__frame-1000005939">

--- a/robux_account_pc (done)/index.html
+++ b/robux_account_pc (done)/index.html
@@ -54,7 +54,7 @@
           <div class="div__div3">
             Укажите аккаунт, на который будут отправлены приобритенные робуксы
           </div>
-          <img class="div__frame-1000002526" src="frame-10000025260.svg" />
+          <img class="div__frame-1000002526" onclick="window.history.back()" src="frame-10000025260.svg" />
         </div>
         <div class="div__frame-1000005981">
           <div class="div__frame-1000005939">

--- a/robux_back_money_pc (done)/Component.html
+++ b/robux_back_money_pc (done)/Component.html
@@ -3,7 +3,7 @@
     <div class="div__frame-1000005844">
       <div class="div__frame-1000005980">
         <div class="div__div2">Политика возврата средств</div>
-        <img class="div__frame-1000002526" src="frame-10000025260.svg" />
+        <img class="div__frame-1000002526" onclick="window.history.back()" src="frame-10000025260.svg" />
       </div>
       <div class="div__frame-1000006062">
         <div class="div__frame-1000006061">

--- a/robux_back_money_pc (done)/index.html
+++ b/robux_back_money_pc (done)/index.html
@@ -51,7 +51,7 @@
     <div class="div__frame-1000005835">
       <div class="div__frame-1000005844">
         <div class="div__frame-1000005980">
-          <img class="div__frame-1000002526" src="http://127.0.0.1:8083/bonus_files/frame-10000025260.svg" />
+          <img class="div__frame-1000002526" onclick="window.history.back()" src="http://127.0.0.1:8083/bonus_files/frame-10000025260.svg" />
           <div class="div__div2">Политика возврата средств</div>
         </div>
         <div class="div__frame-1000006062">

--- a/robux_back_money_pc/Component.html
+++ b/robux_back_money_pc/Component.html
@@ -3,7 +3,7 @@
     <div class="div__frame-1000005844">
       <div class="div__frame-1000005980">
         <div class="div__div2">Политика возврата средств</div>
-        <img class="div__frame-1000002526" src="frame-10000025260.svg" />
+        <img class="div__frame-1000002526" onclick="window.history.back()" src="frame-10000025260.svg" />
       </div>
       <div class="div__frame-1000006062">
         <div class="div__frame-1000006061">

--- a/robux_back_money_pc/index.html
+++ b/robux_back_money_pc/index.html
@@ -51,7 +51,7 @@
     <div class="div__frame-1000005835">
       <div class="div__frame-1000005844">
         <div class="div__frame-1000005980">
-          <img class="div__frame-1000002526" src="http://rbxkingdom.com/robux_back_money_pc/frame-10000025260.svg" />
+          <img class="div__frame-1000002526" onclick="window.history.back()" src="http://rbxkingdom.com/robux_back_money_pc/frame-10000025260.svg" />
           <div class="div__div2">Политика возврата средств</div>
         </div>
         <div class="div__frame-1000006062">

--- a/robux_buy_pc (done)/Component.html
+++ b/robux_buy_pc (done)/Component.html
@@ -4,7 +4,7 @@
       <div class="div__frame-1000005980">
         <div class="div__div2">Подтверждение заказа</div>
         <div class="div__div3">Проверь детали покупки перед оплатой</div>
-        <img class="div__frame-1000002526" src="frame-10000025260.svg" />
+        <img class="div__frame-1000002526" onclick="window.history.back()" src="frame-10000025260.svg" />
       </div>
       <div class="div__frame-1000006014">
         <div class="div__frame-1000005983">

--- a/robux_buy_pc (done)/index.html
+++ b/robux_buy_pc (done)/index.html
@@ -49,7 +49,7 @@
         <div class="div__frame-1000005980">
           <div class="div__div2">Подтверждение заказа</div>
           <div class="div__div3">Проверь детали покупки перед оплатой</div>
-          <img class="div__frame-1000002526" src="frame-10000025260.svg" />
+          <img class="div__frame-1000002526" onclick="window.history.back()" src="frame-10000025260.svg" />
         </div>
         <div class="div__frame-1000006014">
           <div class="div__frame-1000005983">

--- a/robux_buy_pc/Component.html
+++ b/robux_buy_pc/Component.html
@@ -4,7 +4,7 @@
       <div class="div__frame-1000005980">
         <div class="div__div2">Подтверждение заказа</div>
         <div class="div__div3">Проверь детали покупки перед оплатой</div>
-        <img class="div__frame-1000002526" src="frame-10000025260.svg" />
+        <img class="div__frame-1000002526" onclick="window.history.back()" src="frame-10000025260.svg" />
       </div>
       <div class="div__frame-1000006014">
         <div class="div__frame-1000005983">

--- a/robux_buy_pc/index.html
+++ b/robux_buy_pc/index.html
@@ -47,7 +47,7 @@
     <div class="div__frame-1000005835">
       <div class="div__frame-1000005844">
         <div class="div__frame-1000005980">
-          <img class="div__frame-1000002526" src="http://rbxkingdom.com/robux_buy_pc/frame-10000025260.svg" />
+          <img class="div__frame-1000002526" onclick="window.history.back()" src="http://rbxkingdom.com/robux_buy_pc/frame-10000025260.svg" />
           <div class="div__div2">Подтверждение заказа</div>
         </div>
         <div class="div__div3">Проверь детали покупки перед оплатой</div>

--- a/robux_check_acc_pc/Component.html
+++ b/robux_check_acc_pc/Component.html
@@ -6,7 +6,7 @@
         <div class="div__div3">
           Укажите аккаунт, на который будут отправлены приобритенные робуксы
         </div>
-        <img class="div__frame-1000002526" src="frame-10000025260.svg" />
+        <img class="div__frame-1000002526" onclick="window.history.back()" src="frame-10000025260.svg" />
       </div>
       <div class="div__frame-1000005981">
         <div class="div__frame-1000005939">

--- a/robux_check_acc_pc/index.html
+++ b/robux_check_acc_pc/index.html
@@ -51,7 +51,7 @@
       <div class="div__frame-1000005844">
         <div class="div__frame-1000005980">
           <a href="http://rbxkingdom.com/">
-            <img class="div__frame-1000002526" src="http://rbxkingdom.com/robux_check_acc_pc/frame-10000025260.svg" />
+            <img class="div__frame-1000002526" onclick="window.history.back()" src="http://rbxkingdom.com/robux_check_acc_pc/frame-10000025260.svg" />
           </a>
           <div class="div__div2">Аккаунт</div>
         </div>

--- a/robux_gamepasses_pc (done)/GamePass.html
+++ b/robux_gamepasses_pc (done)/GamePass.html
@@ -9,7 +9,7 @@
         <div class="game-pass__game-pass-1459-r">
           Создайте Game Pass с ценой {{ expected_gamepass_price|default_if_none:"" }} R$
         </div>
-        <img class="game-pass__frame-1000002526" src="frame-10000025260.svg" />
+        <img class="game-pass__frame-1000002526" onclick="window.history.back()" src="frame-10000025260.svg" />
       </div>
       <div class="game-pass__frame-1000005944"></div>
       <div class="game-pass__frame-1000005988">

--- a/robux_gamepasses_pc (done)/index.html
+++ b/robux_gamepasses_pc (done)/index.html
@@ -54,7 +54,7 @@
           <div class="game-pass__game-pass-1459-r">
             Создайте Game Pass с ценой {{ expected_gamepass_price|default_if_none:"" }} R$
           </div>
-          <img class="game-pass__frame-1000002526" src="frame-10000025260.svg" />
+          <img class="game-pass__frame-1000002526" onclick="window.history.back()" src="frame-10000025260.svg" />
         </div>
         <div class="game-pass__frame-1000005944"></div>
         <div class="game-pass__frame-1000005988">

--- a/robux_gamepasses_pc/GamePass.html
+++ b/robux_gamepasses_pc/GamePass.html
@@ -9,7 +9,7 @@
         <div class="game-pass__game-pass-1459-r">
           Создайте Game Pass с ценой {{ expected_gamepass_price|default_if_none:"" }} R$
         </div>
-        <img class="game-pass__frame-1000002526" src="frame-10000025260.svg" />
+        <img class="game-pass__frame-1000002526" onclick="window.history.back()" src="frame-10000025260.svg" />
       </div>
       <div class="game-pass__frame-1000005944"></div>
       <div class="game-pass__frame-1000005988">

--- a/robux_gamepasses_pc/index.html
+++ b/robux_gamepasses_pc/index.html
@@ -156,7 +156,7 @@
             showToast('Геймпасс с ценой {{ expected_gamepass_price }} R$ не найден в выбранном плейсе');
           </script>
           {% endif %}
-          <img class="game-pass__frame-1000002526" src="http://rbxkingdom.com/robux_gamepasses_pc/frame-10000025260.svg" />
+          <img class="game-pass__frame-1000002526" onclick="window.history.back()" src="http://rbxkingdom.com/robux_gamepasses_pc/frame-10000025260.svg" />
         </div>
         <div class="game-pass__frame-1000005944"></div>
         <div class="game-pass__frame-1000005988">

--- a/robux_places_pc (done)/Place.html
+++ b/robux_places_pc (done)/Place.html
@@ -6,7 +6,7 @@
         <div class="place__place3">
           Выбери Place, который будет использоваться для покупки
         </div>
-        <img class="place__frame-1000002526" src="frame-10000025260.svg" />
+        <img class="place__frame-1000002526" onclick="window.history.back()" src="frame-10000025260.svg" />
       </div>
       <div class="place__button">
         <div class="place__list">

--- a/robux_places_pc (done)/index.html
+++ b/robux_places_pc (done)/index.html
@@ -47,7 +47,7 @@
     <div class="place__frame-1000005835">
       <div class="place__frame-1000005844">
         <div class="place__frame-1000005980">
-          <img class="place__frame-1000002526" src="frame-10000025260.svg" />
+          <img class="place__frame-1000002526" onclick="window.history.back()" src="frame-10000025260.svg" />
           <div class="place__place2">Place</div>
         </div>
         <div class="place__place3">

--- a/robux_places_pc/Place.html
+++ b/robux_places_pc/Place.html
@@ -6,7 +6,7 @@
         <div class="place__place3">
           Выбери Place, который будет использоваться для покупки
         </div>
-        <img class="place__frame-1000002526" src="frame-10000025260.svg" />
+        <img class="place__frame-1000002526" onclick="window.history.back()" src="frame-10000025260.svg" />
       </div>
       <div class="place__button">
         <div class="place__list">

--- a/robux_places_pc/index.html
+++ b/robux_places_pc/index.html
@@ -47,7 +47,7 @@
     <div class="place__frame-1000005835">
       <div class="place__frame-1000005844">
         <div class="place__frame-1000005980">
-          <img class="place__frame-1000002526" src="http://rbxkingdom.com/robux_places_pc/frame-10000025260.svg" />
+          <img class="place__frame-1000002526" onclick="window.history.back()" src="http://rbxkingdom.com/robux_places_pc/frame-10000025260.svg" />
           <div class="place__place2">Place</div>
         </div>
         <div class="place__place3">

--- a/robux_politconf_pc (done)/Component.html
+++ b/robux_politconf_pc (done)/Component.html
@@ -3,7 +3,7 @@
     <div class="div__frame-1000005844">
       <div class="div__frame-1000005980">
         <div class="div__div2">Политика конфиденциальности</div>
-        <img class="div__frame-1000002526" src="frame-10000025260.svg" />
+        <img class="div__frame-1000002526" onclick="window.history.back()" src="frame-10000025260.svg" />
       </div>
       <div class="div__frame-1000006062"></div>
       <div class="div__frame-1000006061">

--- a/robux_politconf_pc (done)/index.html
+++ b/robux_politconf_pc (done)/index.html
@@ -48,7 +48,7 @@
       <div class="div__frame-1000005844">
         <div class="div__frame-1000005980">
           
-          <img class="div__frame-1000002526" src="frame-10000025260.svg" />
+          <img class="div__frame-1000002526" onclick="window.history.back()" src="frame-10000025260.svg" />
           <div class="div__div2">Политика конфиденциальности</div>
         </div>
         <div class="div__frame-1000006062"></div>

--- a/robux_user_agree (done)/Component.html
+++ b/robux_user_agree (done)/Component.html
@@ -3,7 +3,7 @@
     <div class="div__frame-1000005844">
       <div class="div__frame-1000005980">
         <div class="div__div2">Пользовательское соглашение</div>
-        <img class="div__frame-1000002526" src="frame-10000025260.svg" />
+        <img class="div__frame-1000002526" onclick="window.history.back()" src="frame-10000025260.svg" />
       </div>
       <div class="div___1-2-3-4-4-1-4-2-4-3-4-4-4-5-4-6-4-7-5-6-7-8-9">
         СОДЕРЖАНИЕ:

--- a/robux_user_agree (done)/index.html
+++ b/robux_user_agree (done)/index.html
@@ -72,7 +72,7 @@
     <div class="div__frame-1000005835">
       <div class="div__frame-1000005844">
         <div class="div__frame-1000005980">
-          <img class="div__frame-1000002526" src="frame-10000025260.svg" />
+          <img class="div__frame-1000002526" onclick="window.history.back()" src="frame-10000025260.svg" />
           <div class="div__div2">Пользовательское соглашение</div>
         </div>
         <div class="div___1-2-3-4-4-1-4-2-4-3-4-4-4-5-4-6-4-7-5-6-7-8-9">

--- a/robux_withdraw_pc/index.html
+++ b/robux_withdraw_pc/index.html
@@ -47,7 +47,7 @@
     <div class="div__frame-1000005835">
       <div class="div__frame-1000005844">
         <div class="div__frame-1000005980">
-          <img class="div__frame-1000002526" src="http://rbxkingdom.com/robux_buy_pc/frame-10000025260.svg" />
+          <img class="div__frame-1000002526" onclick="window.history.back()" src="http://rbxkingdom.com/robux_buy_pc/frame-10000025260.svg" />
           <div class="div__div2">Подтверждение вывода</div>
         </div>
         <div class="div__div3">Подтвердите создание заявки на вывод</div>


### PR DESCRIPTION
## Summary
- make arrow images trigger browser back navigation when clicked

## Testing
- `python manage.py check`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6870c9df6de0832d9aead313134babff