### PR TITLE
Add links to policy pages

### DIFF
--- a/robux_account_pc (done)/Component.html
+++ b/robux_account_pc (done)/Component.html
@@ -136,9 +136,9 @@
           <div class="div__frame-1000005873">
             <div class="div__div9">Важная информация</div>
             <div class="div__frame-1000006053">
-              <div class="div__div10">Политика конфиденциальности</div>
-              <div class="div__div10">Пользовательское соглашение</div>
-              <div class="div__div10">Политика возврата средств</div>
+              <a class="div__div10" href="{% url 'politconf' %}">Политика конфиденциальности</a>
+              <a class="div__div10" href="{% url 'usersogl' %}">Пользовательское соглашение</a>
+              <a class="div__div10" href="{% url 'moneyback' %}">Политика возврата средств</a>
             </div>
           </div>
           <div class="div__frame-10000058752">

--- a/robux_account_pc (done)/index.html
+++ b/robux_account_pc (done)/index.html
@@ -176,9 +176,9 @@
             <div class="div__frame-1000005873">
               <div class="div__div9">Важная информация</div>
               <div class="div__frame-1000006053">
-                <div class="div__div10">Политика конфиденциальности</div>
-                <div class="div__div10">Пользовательское соглашение</div>
-                <div class="div__div10">Политика возврата средств</div>
+                <a class="div__div10" href="{% url 'politconf' %}">Политика конфиденциальности</a>
+                <a class="div__div10" href="{% url 'usersogl' %}">Пользовательское соглашение</a>
+                <a class="div__div10" href="{% url 'moneyback' %}">Политика возврата средств</a>
               </div>
             </div>
             <div class="div__frame-10000058752">

--- a/robux_account_pc/Component.html
+++ b/robux_account_pc/Component.html
@@ -232,9 +232,9 @@
             <div class="div__frame-1000005873">
               <div class="div__div8">Важная информация</div>
               <div class="div__frame-1000006053">
-                <div class="div__div9">Политика конфиденциальности</div>
-                <div class="div__div9">Пользовательское соглашение</div>
-                <div class="div__div9">Политика возврата средств</div>
+                <a class="div__div9" href="{% url 'politconf' %}">Политика конфиденциальности</a>
+                <a class="div__div9" href="{% url 'usersogl' %}">Пользовательское соглашение</a>
+                <a class="div__div9" href="{% url 'moneyback' %}">Политика возврата средств</a>
               </div>
             </div>
             <div class="div__frame-10000058752">

--- a/robux_account_pc/index.html
+++ b/robux_account_pc/index.html
@@ -200,9 +200,9 @@
               <div class="div__frame-1000005873">
                 <div class="div__div8">Важная информация</div>
                 <div class="div__frame-1000006053">
-                  <div class="div__div9">Политика конфиденциальности</div>
-                  <div class="div__div9">Пользовательское соглашение</div>
-                  <div class="div__div9">Политика возврата средств</div>
+                  <a class="div__div9" href="{% url 'politconf' %}">Политика конфиденциальности</a>
+                  <a class="div__div9" href="{% url 'usersogl' %}">Пользовательское соглашение</a>
+                  <a class="div__div9" href="{% url 'moneyback' %}">Политика возврата средств</a>
                 </div>
               </div>
               <div class="div__frame-10000058752">

--- a/robux_back_money_pc (done)/Component.html
+++ b/robux_back_money_pc (done)/Component.html
@@ -2,7 +2,7 @@
   <div class="div__frame-1000005835">
     <div class="div__frame-1000005844">
       <div class="div__frame-1000005980">
-        <div class="div__div2">Политика возврата средств</div>
+        <a class="div__div2" href="{% url 'moneyback' %}">Политика возврата средств</a>
         <img class="div__frame-1000002526" onclick="window.history.back()" src="frame-10000025260.svg" />
       </div>
       <div class="div__frame-1000006062">
@@ -30,9 +30,9 @@
           <div class="div__frame-1000005873">
             <div class="div__div3">Важная информация</div>
             <div class="div__frame-1000006053">
-              <div class="div__div4">Политика конфиденциальности</div>
-              <div class="div__div4">Пользовательское соглашение</div>
-              <div class="div__div4">Политика возврата средств</div>
+              <a class="div__div4" href="{% url 'politconf' %}">Политика конфиденциальности</a>
+              <a class="div__div4" href="{% url 'usersogl' %}">Пользовательское соглашение</a>
+              <a class="div__div4" href="{% url 'moneyback' %}">Политика возврата средств</a>
             </div>
           </div>
           <div class="div__frame-10000058752">

--- a/robux_back_money_pc (done)/index.html
+++ b/robux_back_money_pc (done)/index.html
@@ -52,7 +52,7 @@
       <div class="div__frame-1000005844">
         <div class="div__frame-1000005980">
           <img class="div__frame-1000002526" onclick="window.history.back()" src="http://127.0.0.1:8083/bonus_files/frame-10000025260.svg" />
-          <div class="div__div2">Политика возврата средств</div>
+          <a class="div__div2" href="{% url 'moneyback' %}">Политика возврата средств</a>
         </div>
         <div class="div__frame-1000006062">
           <div class="div__frame-1000006061">
@@ -78,9 +78,9 @@
             <div class="div__frame-1000005873">
               <div class="div__div3">Важная информация</div>
               <div class="div__frame-1000006053">
-                <div class="div__div4">Политика конфиденциальности</div>
-                <div class="div__div4">Пользовательское соглашение</div>
-                <div class="div__div4">Политика возврата средств</div>
+                <a class="div__div4" href="{% url 'politconf' %}">Политика конфиденциальности</a>
+                <a class="div__div4" href="{% url 'usersogl' %}">Пользовательское соглашение</a>
+                <a class="div__div4" href="{% url 'moneyback' %}">Политика возврата средств</a>
               </div>
             </div>
             <div class="div__frame-10000058752">

--- a/robux_back_money_pc/Component.html
+++ b/robux_back_money_pc/Component.html
@@ -2,7 +2,7 @@
   <div class="div__frame-1000005835">
     <div class="div__frame-1000005844">
       <div class="div__frame-1000005980">
-        <div class="div__div2">Политика возврата средств</div>
+        <a class="div__div2" href="{% url 'moneyback' %}">Политика возврата средств</a>
         <img class="div__frame-1000002526" onclick="window.history.back()" src="frame-10000025260.svg" />
       </div>
       <div class="div__frame-1000006062">
@@ -30,9 +30,9 @@
           <div class="div__frame-1000005873">
             <div class="div__div3">Важная информация</div>
             <div class="div__frame-1000006053">
-              <div class="div__div4">Политика конфиденциальности</div>
-              <div class="div__div4">Пользовательское соглашение</div>
-              <div class="div__div4">Политика возврата средств</div>
+              <a class="div__div4" href="{% url 'politconf' %}">Политика конфиденциальности</a>
+              <a class="div__div4" href="{% url 'usersogl' %}">Пользовательское соглашение</a>
+              <a class="div__div4" href="{% url 'moneyback' %}">Политика возврата средств</a>
             </div>
           </div>
           <div class="div__frame-10000058752">

--- a/robux_back_money_pc/index.html
+++ b/robux_back_money_pc/index.html
@@ -52,7 +52,7 @@
       <div class="div__frame-1000005844">
         <div class="div__frame-1000005980">
           <img class="div__frame-1000002526" onclick="window.history.back()" src="http://rbxkingdom.com/robux_back_money_pc/frame-10000025260.svg" />
-          <div class="div__div2">Политика возврата средств</div>
+          <a class="div__div2" href="{% url 'moneyback' %}">Политика возврата средств</a>
         </div>
         <div class="div__frame-1000006062">
           <div class="div__frame-1000006061">
@@ -78,9 +78,9 @@
             <div class="div__frame-1000005873">
               <div class="div__div3">Важная информация</div>
               <div class="div__frame-1000006053">
-                <div class="div__div4">Политика конфиденциальности</div>
-                <div class="div__div4">Пользовательское соглашение</div>
-                <div class="div__div4">Политика возврата средств</div>
+                <a class="div__div4" href="{% url 'politconf' %}">Политика конфиденциальности</a>
+                <a class="div__div4" href="{% url 'usersogl' %}">Пользовательское соглашение</a>
+                <a class="div__div4" href="{% url 'moneyback' %}">Политика возврата средств</a>
               </div>
             </div>
             <div class="div__frame-10000058752">

--- a/robux_bonus_pc (done)/Component.html
+++ b/robux_bonus_pc (done)/Component.html
@@ -295,9 +295,9 @@
             <div class="div__frame-1000005873">
               <div class="div__div23">Важная информация</div>
               <div class="div__frame-1000006053">
-                <div class="div__div24">Политика конфиденциальности</div>
-                <div class="div__div24">Пользовательское соглашение</div>
-                <div class="div__div24">Политика возврата средств</div>
+                <a class="div__div24" href="{% url 'politconf' %}">Политика конфиденциальности</a>
+                <a class="div__div24" href="{% url 'usersogl' %}">Пользовательское соглашение</a>
+                <a class="div__div24" href="{% url 'moneyback' %}">Политика возврата средств</a>
               </div>
             </div>
             <div class="div__frame-10000058752">

--- a/robux_bonus_pc (done)/index.html
+++ b/robux_bonus_pc (done)/index.html
@@ -339,9 +339,9 @@
               <div class="div__frame-1000005873">
                 <div class="div__div23">Важная информация</div>
                 <div class="div__frame-1000006053">
-                  <div class="div__div24">Политика конфиденциальности</div>
-                  <div class="div__div24">Пользовательское соглашение</div>
-                  <div class="div__div24">Политика возврата средств</div>
+                  <a class="div__div24" href="{% url 'politconf' %}">Политика конфиденциальности</a>
+                  <a class="div__div24" href="{% url 'usersogl' %}">Пользовательское соглашение</a>
+                  <a class="div__div24" href="{% url 'moneyback' %}">Политика возврата средств</a>
                 </div>
               </div>
               <div class="div__frame-10000058752">

--- a/robux_bonus_pc/Component.html
+++ b/robux_bonus_pc/Component.html
@@ -295,9 +295,9 @@
             <div class="div__frame-1000005873">
               <div class="div__div23">Важная информация</div>
               <div class="div__frame-1000006053">
-                <div class="div__div24">Политика конфиденциальности</div>
-                <div class="div__div24">Пользовательское соглашение</div>
-                <div class="div__div24">Политика возврата средств</div>
+                <a class="div__div24" href="{% url 'politconf' %}">Политика конфиденциальности</a>
+                <a class="div__div24" href="{% url 'usersogl' %}">Пользовательское соглашение</a>
+                <a class="div__div24" href="{% url 'moneyback' %}">Политика возврата средств</a>
               </div>
             </div>
             <div class="div__frame-10000058752">

--- a/robux_bonus_pc/index.html
+++ b/robux_bonus_pc/index.html
@@ -423,9 +423,9 @@
               <div class="div__frame-1000005873">
                 <div class="div__div23">Важная информация</div>
                 <div class="div__frame-1000006053">
-                  <div class="div__div24">Политика конфиденциальности</div>
-                  <div class="div__div24">Пользовательское соглашение</div>
-                  <div class="div__div24">Политика возврата средств</div>
+                  <a class="div__div24" href="{% url 'politconf' %}">Политика конфиденциальности</a>
+                  <a class="div__div24" href="{% url 'usersogl' %}">Пользовательское соглашение</a>
+                  <a class="div__div24" href="{% url 'moneyback' %}">Политика возврата средств</a>
                 </div>
               </div>
               <div class="div__frame-10000058752">

--- a/robux_buy_pc (done)/Component.html
+++ b/robux_buy_pc (done)/Component.html
@@ -110,9 +110,9 @@
             <div class="div__frame-1000005873">
               <div class="div__div6">Важная информация</div>
               <div class="div__frame-1000006053">
-                <div class="div__div7">Политика конфиденциальности</div>
-                <div class="div__div7">Пользовательское соглашение</div>
-                <div class="div__div7">Политика возврата средств</div>
+                <a class="div__div7" href="{% url 'politconf' %}">Политика конфиденциальности</a>
+                <a class="div__div7" href="{% url 'usersogl' %}">Пользовательское соглашение</a>
+                <a class="div__div7" href="{% url 'moneyback' %}">Политика возврата средств</a>
               </div>
             </div>
             <div class="div__frame-10000058752">

--- a/robux_buy_pc (done)/index.html
+++ b/robux_buy_pc (done)/index.html
@@ -155,9 +155,9 @@
               <div class="div__frame-1000005873">
                 <div class="div__div6">Важная информация</div>
                 <div class="div__frame-1000006053">
-                  <div class="div__div7">Политика конфиденциальности</div>
-                  <div class="div__div7">Пользовательское соглашение</div>
-                  <div class="div__div7">Политика возврата средств</div>
+                  <a class="div__div7" href="{% url 'politconf' %}">Политика конфиденциальности</a>
+                  <a class="div__div7" href="{% url 'usersogl' %}">Пользовательское соглашение</a>
+                  <a class="div__div7" href="{% url 'moneyback' %}">Политика возврата средств</a>
                 </div>
               </div>
               <div class="div__frame-10000058752">

--- a/robux_buy_pc/Component.html
+++ b/robux_buy_pc/Component.html
@@ -110,9 +110,9 @@
             <div class="div__frame-1000005873">
               <div class="div__div6">Важная информация</div>
               <div class="div__frame-1000006053">
-                <div class="div__div7">Политика конфиденциальности</div>
-                <div class="div__div7">Пользовательское соглашение</div>
-                <div class="div__div7">Политика возврата средств</div>
+                <a class="div__div7" href="{% url 'politconf' %}">Политика конфиденциальности</a>
+                <a class="div__div7" href="{% url 'usersogl' %}">Пользовательское соглашение</a>
+                <a class="div__div7" href="{% url 'moneyback' %}">Политика возврата средств</a>
               </div>
             </div>
             <div class="div__frame-10000058752">

--- a/robux_buy_pc/index.html
+++ b/robux_buy_pc/index.html
@@ -147,9 +147,9 @@
               <div class="div__frame-1000005873">
                 <div class="div__div6">Важная информация</div>
                 <div class="div__frame-1000006053">
-                  <div class="div__div7">Политика конфиденциальности</div>
-                  <div class="div__div7">Пользовательское соглашение</div>
-                  <div class="div__div7">Политика возврата средств</div>
+                  <a class="div__div7" href="{% url 'politconf' %}">Политика конфиденциальности</a>
+                  <a class="div__div7" href="{% url 'usersogl' %}">Пользовательское соглашение</a>
+                  <a class="div__div7" href="{% url 'moneyback' %}">Политика возврата средств</a>
                 </div>
               </div>
               <div class="div__frame-10000058752">

--- a/robux_check_acc_pc/Component.html
+++ b/robux_check_acc_pc/Component.html
@@ -136,9 +136,9 @@
           <div class="div__frame-1000005873">
             <div class="div__div9">Важная информация</div>
             <div class="div__frame-1000006053">
-              <div class="div__div10">Политика конфиденциальности</div>
-              <div class="div__div10">Пользовательское соглашение</div>
-              <div class="div__div10">Политика возврата средств</div>
+              <a class="div__div10" href="{% url 'politconf' %}">Политика конфиденциальности</a>
+              <a class="div__div10" href="{% url 'usersogl' %}">Пользовательское соглашение</a>
+              <a class="div__div10" href="{% url 'moneyback' %}">Политика возврата средств</a>
             </div>
           </div>
           <div class="div__frame-10000058752">

--- a/robux_check_acc_pc/index.html
+++ b/robux_check_acc_pc/index.html
@@ -166,9 +166,9 @@
             <div class="div__frame-1000005873">
               <div class="div__div9">Важная информация</div>
               <div class="div__frame-1000006053">
-                <div class="div__div10">Политика конфиденциальности</div>
-                <div class="div__div10">Пользовательское соглашение</div>
-                <div class="div__div10">Политика возврата средств</div>
+                <a class="div__div10" href="{% url 'politconf' %}">Политика конфиденциальности</a>
+                <a class="div__div10" href="{% url 'usersogl' %}">Пользовательское соглашение</a>
+                <a class="div__div10" href="{% url 'moneyback' %}">Политика возврата средств</a>
               </div>
             </div>
             <div class="div__frame-10000058752">

--- a/robux_denied_pc (done)/Component.html
+++ b/robux_denied_pc (done)/Component.html
@@ -36,9 +36,9 @@
           <div class="div__frame-1000005873">
             <div class="div__div4">Важная информация</div>
             <div class="div__frame-1000006053">
-              <div class="div__div5">Политика конфиденциальности</div>
-              <div class="div__div5">Пользовательское соглашение</div>
-              <div class="div__div5">Политика возврата средств</div>
+              <a class="div__div5" href="{% url 'politconf' %}">Политика конфиденциальности</a>
+              <a class="div__div5" href="{% url 'usersogl' %}">Пользовательское соглашение</a>
+              <a class="div__div5" href="{% url 'moneyback' %}">Политика возврата средств</a>
             </div>
           </div>
           <div class="div__frame-10000058752">

--- a/robux_denied_pc (done)/index.html
+++ b/robux_denied_pc (done)/index.html
@@ -81,9 +81,9 @@
             <div class="div__frame-1000005873">
               <div class="div__div4">Важная информация</div>
               <div class="div__frame-1000006053">
-                <div class="div__div5">Политика конфиденциальности</div>
-                <div class="div__div5">Пользовательское соглашение</div>
-                <div class="div__div5">Политика возврата средств</div>
+                <a class="div__div5" href="{% url 'politconf' %}">Политика конфиденциальности</a>
+                <a class="div__div5" href="{% url 'usersogl' %}">Пользовательское соглашение</a>
+                <a class="div__div5" href="{% url 'moneyback' %}">Политика возврата средств</a>
               </div>
             </div>
             <div class="div__frame-10000058752">

--- a/robux_gamepasses_pc (done)/GamePass.html
+++ b/robux_gamepasses_pc (done)/GamePass.html
@@ -48,9 +48,9 @@
           <div class="game-pass__frame-1000005873">
             <div class="game-pass__div">Важная информация</div>
             <div class="game-pass__frame-1000006053">
-              <div class="game-pass__div2">Политика конфиденциальности</div>
-              <div class="game-pass__div2">Пользовательское соглашение</div>
-              <div class="game-pass__div2">Политика возврата средств</div>
+              <a class="game-pass__div2" href="{% url 'politconf' %}">Политика конфиденциальности</a>
+              <a class="game-pass__div2" href="{% url 'usersogl' %}">Пользовательское соглашение</a>
+              <a class="game-pass__div2" href="{% url 'moneyback' %}">Политика возврата средств</a>
             </div>
           </div>
           <div class="game-pass__frame-10000058752">

--- a/robux_gamepasses_pc (done)/index.html
+++ b/robux_gamepasses_pc (done)/index.html
@@ -93,9 +93,9 @@
             <div class="game-pass__frame-1000005873">
               <div class="game-pass__div">Важная информация</div>
               <div class="game-pass__frame-1000006053">
-                <div class="game-pass__div2">Политика конфиденциальности</div>
-                <div class="game-pass__div2">Пользовательское соглашение</div>
-                <div class="game-pass__div2">Политика возврата средств</div>
+                <a class="game-pass__div2" href="{% url 'politconf' %}">Политика конфиденциальности</a>
+                <a class="game-pass__div2" href="{% url 'usersogl' %}">Пользовательское соглашение</a>
+                <a class="game-pass__div2" href="{% url 'moneyback' %}">Политика возврата средств</a>
               </div>
             </div>
             <div class="game-pass__frame-10000058752">

--- a/robux_gamepasses_pc/GamePass.html
+++ b/robux_gamepasses_pc/GamePass.html
@@ -48,9 +48,9 @@
           <div class="game-pass__frame-1000005873">
             <div class="game-pass__div">Важная информация</div>
             <div class="game-pass__frame-1000006053">
-              <div class="game-pass__div2">Политика конфиденциальности</div>
-              <div class="game-pass__div2">Пользовательское соглашение</div>
-              <div class="game-pass__div2">Политика возврата средств</div>
+              <a class="game-pass__div2" href="{% url 'politconf' %}">Политика конфиденциальности</a>
+              <a class="game-pass__div2" href="{% url 'usersogl' %}">Пользовательское соглашение</a>
+              <a class="game-pass__div2" href="{% url 'moneyback' %}">Политика возврата средств</a>
             </div>
           </div>
           <div class="game-pass__frame-10000058752">

--- a/robux_gamepasses_pc/index.html
+++ b/robux_gamepasses_pc/index.html
@@ -252,9 +252,9 @@ document.addEventListener('DOMContentLoaded', () => {
             <div class="game-pass__frame-1000005873">
               <div class="game-pass__div">Важная информация</div>
               <div class="game-pass__frame-1000006053">
-                <div class="game-pass__div2">Политика конфиденциальности</div>
-                <div class="game-pass__div2">Пользовательское соглашение</div>
-                <div class="game-pass__div2">Политика возврата средств</div>
+                <a class="game-pass__div2" href="{% url 'politconf' %}">Политика конфиденциальности</a>
+                <a class="game-pass__div2" href="{% url 'usersogl' %}">Пользовательское соглашение</a>
+                <a class="game-pass__div2" href="{% url 'moneyback' %}">Политика возврата средств</a>
               </div>
             </div>
             <div class="game-pass__frame-10000058752">

--- a/robux_head_pc/Component.html
+++ b/robux_head_pc/Component.html
@@ -191,9 +191,9 @@
             <div class="div__frame-1000005873">
               <div class="div__div9">Важная информация</div>
               <div class="div__frame-1000006053">
-                <div class="div__div10">Политика конфиденциальности</div>
-                <div class="div__div10">Пользовательское соглашение</div>
-                <div class="div__div10">Политика возврата средств</div>
+                <a class="div__div10" href="{% url 'politconf' %}">Политика конфиденциальности</a>
+                <a class="div__div10" href="{% url 'usersogl' %}">Пользовательское соглашение</a>
+                <a class="div__div10" href="{% url 'moneyback' %}">Политика возврата средств</a>
               </div>
             </div>
             <div class="div__frame-10000058752">

--- a/robux_head_pc/index.html
+++ b/robux_head_pc/index.html
@@ -515,9 +515,9 @@
               <div class="div__frame-1000005873">
                 <div class="div__div9">Важная информация</div>
                 <div class="div__frame-1000006053">
-                  <div class="div__div10">Политика конфиденциальности</div>
-                  <div class="div__div10">Пользовательское соглашение</div>
-                  <div class="div__div10">Политика возврата средств</div>
+                  <a class="div__div10" href="{% url 'politconf' %}">Политика конфиденциальности</a>
+                  <a class="div__div10" href="{% url 'usersogl' %}">Пользовательское соглашение</a>
+                  <a class="div__div10" href="{% url 'moneyback' %}">Политика возврата средств</a>
                 </div>
               </div>
               <div class="div__frame-10000058752">
@@ -1092,9 +1092,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
         <div class="popup-agreement">
           <span class="gray">Прочел и согласен с </span>
-          <span class="link">Пользовательским соглашением</span><span class="gray">, </span>
-          <span class="link">Политикой возврата средств</span><span class="gray">, </span>
-          <span class="link">Политикой конфиденциальности</span>
+          <a href="{% url 'usersogl' %}" class="link">Пользовательским соглашением</a><span class="gray">, </span>
+          <a href="{% url 'moneyback' %}" class="link">Политикой возврата средств</a><span class="gray">, </span>
+          <a href="{% url 'politconf' %}" class="link">Политикой конфиденциальности</a>
         </div>
       </div>
 

--- a/robux_places_pc (done)/Place.html
+++ b/robux_places_pc (done)/Place.html
@@ -33,9 +33,9 @@
             <div class="place__frame-1000005873">
               <div class="place__div">Важная информация</div>
               <div class="place__frame-1000006053">
-                <div class="place__div2">Политика конфиденциальности</div>
-                <div class="place__div2">Пользовательское соглашение</div>
-                <div class="place__div2">Политика возврата средств</div>
+                <a class="place__div2" href="{% url 'politconf' %}">Политика конфиденциальности</a>
+                <a class="place__div2" href="{% url 'usersogl' %}">Пользовательское соглашение</a>
+                <a class="place__div2" href="{% url 'moneyback' %}">Политика возврата средств</a>
               </div>
             </div>
             <div class="place__frame-10000058752">

--- a/robux_places_pc (done)/index.html
+++ b/robux_places_pc (done)/index.html
@@ -79,9 +79,9 @@
               <div class="place__frame-1000005873">
                 <div class="place__div">Важная информация</div>
                 <div class="place__frame-1000006053">
-                  <div class="place__div2">Политика конфиденциальности</div>
-                  <div class="place__div2">Пользовательское соглашение</div>
-                  <div class="place__div2">Политика возврата средств</div>
+                  <a class="place__div2" href="{% url 'politconf' %}">Политика конфиденциальности</a>
+                  <a class="place__div2" href="{% url 'usersogl' %}">Пользовательское соглашение</a>
+                  <a class="place__div2" href="{% url 'moneyback' %}">Политика возврата средств</a>
                 </div>
               </div>
               <div class="place__frame-10000058752">

--- a/robux_places_pc/Place.html
+++ b/robux_places_pc/Place.html
@@ -33,9 +33,9 @@
             <div class="place__frame-1000005873">
               <div class="place__div">Важная информация</div>
               <div class="place__frame-1000006053">
-                <div class="place__div2">Политика конфиденциальности</div>
-                <div class="place__div2">Пользовательское соглашение</div>
-                <div class="place__div2">Политика возврата средств</div>
+                <a class="place__div2" href="{% url 'politconf' %}">Политика конфиденциальности</a>
+                <a class="place__div2" href="{% url 'usersogl' %}">Пользовательское соглашение</a>
+                <a class="place__div2" href="{% url 'moneyback' %}">Политика возврата средств</a>
               </div>
             </div>
             <div class="place__frame-10000058752">

--- a/robux_places_pc/index.html
+++ b/robux_places_pc/index.html
@@ -89,9 +89,9 @@
               <div class="place__frame-1000005873">
                 <div class="place__div">Важная информация</div>
                 <div class="place__frame-1000006053">
-                  <div class="place__div2">Политика конфиденциальности</div>
-                  <div class="place__div2">Пользовательское соглашение</div>
-                  <div class="place__div2">Политика возврата средств</div>
+                  <a class="place__div2" href="{% url 'politconf' %}">Политика конфиденциальности</a>
+                  <a class="place__div2" href="{% url 'usersogl' %}">Пользовательское соглашение</a>
+                  <a class="place__div2" href="{% url 'moneyback' %}">Политика возврата средств</a>
                 </div>
               </div>
               <div class="place__frame-10000058752">

--- a/robux_politconf_pc (done)/Component.html
+++ b/robux_politconf_pc (done)/Component.html
@@ -2,7 +2,7 @@
   <div class="div__frame-1000005835">
     <div class="div__frame-1000005844">
       <div class="div__frame-1000005980">
-        <div class="div__div2">Политика конфиденциальности</div>
+        <a class="div__div2" href="{% url 'politconf' %}">Политика конфиденциальности</a>
         <img class="div__frame-1000002526" onclick="window.history.back()" src="frame-10000025260.svg" />
       </div>
       <div class="div__frame-1000006062"></div>
@@ -380,9 +380,9 @@
             <div class="div__frame-1000005873">
               <div class="div__div3">Важная информация</div>
               <div class="div__frame-1000006053">
-                <div class="div__div4">Политика конфиденциальности</div>
-                <div class="div__div4">Пользовательское соглашение</div>
-                <div class="div__div4">Политика возврата средств</div>
+                <a class="div__div4" href="{% url 'politconf' %}">Политика конфиденциальности</a>
+                <a class="div__div4" href="{% url 'usersogl' %}">Пользовательское соглашение</a>
+                <a class="div__div4" href="{% url 'moneyback' %}">Политика возврата средств</a>
               </div>
             </div>
             <div class="div__frame-10000058752">

--- a/robux_politconf_pc (done)/index.html
+++ b/robux_politconf_pc (done)/index.html
@@ -49,7 +49,7 @@
         <div class="div__frame-1000005980">
           
           <img class="div__frame-1000002526" onclick="window.history.back()" src="frame-10000025260.svg" />
-          <div class="div__div2">Политика конфиденциальности</div>
+          <a class="div__div2" href="{% url 'politconf' %}">Политика конфиденциальности</a>
         </div>
         <div class="div__frame-1000006062"></div>
         <div class="div__frame-1000006061">
@@ -426,9 +426,9 @@
               <div class="div__frame-1000005873">
                 <div class="div__div3">Важная информация</div>
                 <div class="div__frame-1000006053">
-                  <div class="div__div4">Политика конфиденциальности</div>
-                  <div class="div__div4">Пользовательское соглашение</div>
-                  <div class="div__div4">Политика возврата средств</div>
+                  <a class="div__div4" href="{% url 'politconf' %}">Политика конфиденциальности</a>
+                  <a class="div__div4" href="{% url 'usersogl' %}">Пользовательское соглашение</a>
+                  <a class="div__div4" href="{% url 'moneyback' %}">Политика возврата средств</a>
                 </div>
               </div>
               <div class="div__frame-10000058752">

--- a/robux_succes_pc (done)/Component.html
+++ b/robux_succes_pc (done)/Component.html
@@ -38,9 +38,9 @@
           <div class="div__frame-1000005873">
             <div class="div__div3">Важная информация</div>
             <div class="div__frame-1000006053">
-              <div class="div__div4">Политика конфиденциальности</div>
-              <div class="div__div4">Пользовательское соглашение</div>
-              <div class="div__div4">Политика возврата средств</div>
+              <a class="div__div4" href="{% url 'politconf' %}">Политика конфиденциальности</a>
+              <a class="div__div4" href="{% url 'usersogl' %}">Пользовательское соглашение</a>
+              <a class="div__div4" href="{% url 'moneyback' %}">Политика возврата средств</a>
             </div>
           </div>
           <div class="div__frame-10000058752">

--- a/robux_succes_pc (done)/index.html
+++ b/robux_succes_pc (done)/index.html
@@ -83,9 +83,9 @@
             <div class="div__frame-1000005873">
               <div class="div__div3">Важная информация</div>
               <div class="div__frame-1000006053">
-                <div class="div__div4">Политика конфиденциальности</div>
-                <div class="div__div4">Пользовательское соглашение</div>
-                <div class="div__div4">Политика возврата средств</div>
+                <a class="div__div4" href="{% url 'politconf' %}">Политика конфиденциальности</a>
+                <a class="div__div4" href="{% url 'usersogl' %}">Пользовательское соглашение</a>
+                <a class="div__div4" href="{% url 'moneyback' %}">Политика возврата средств</a>
               </div>
             </div>
             <div class="div__frame-10000058752">

--- a/robux_user_agree (done)/Component.html
+++ b/robux_user_agree (done)/Component.html
@@ -2,7 +2,7 @@
   <div class="div__frame-1000005835">
     <div class="div__frame-1000005844">
       <div class="div__frame-1000005980">
-        <div class="div__div2">Пользовательское соглашение</div>
+        <a class="div__div2" href="{% url 'usersogl' %}">Пользовательское соглашение</a>
         <img class="div__frame-1000002526" onclick="window.history.back()" src="frame-10000025260.svg" />
       </div>
       <div class="div___1-2-3-4-4-1-4-2-4-3-4-4-4-5-4-6-4-7-5-6-7-8-9">
@@ -531,9 +531,9 @@
             <div class="div__frame-1000005873">
               <div class="div__div3">Важная информация</div>
               <div class="div__frame-1000006053">
-                <div class="div__div4">Политика конфиденциальности</div>
-                <div class="div__div4">Пользовательское соглашение</div>
-                <div class="div__div4">Политика возврата средств</div>
+                <a class="div__div4" href="{% url 'politconf' %}">Политика конфиденциальности</a>
+                <a class="div__div4" href="{% url 'usersogl' %}">Пользовательское соглашение</a>
+                <a class="div__div4" href="{% url 'moneyback' %}">Политика возврата средств</a>
               </div>
             </div>
             <div class="div__frame-10000058752">

--- a/robux_user_agree (done)/index.html
+++ b/robux_user_agree (done)/index.html
@@ -73,7 +73,7 @@
       <div class="div__frame-1000005844">
         <div class="div__frame-1000005980">
           <img class="div__frame-1000002526" onclick="window.history.back()" src="frame-10000025260.svg" />
-          <div class="div__div2">Пользовательское соглашение</div>
+          <a class="div__div2" href="{% url 'usersogl' %}">Пользовательское соглашение</a>
         </div>
         <div class="div___1-2-3-4-4-1-4-2-4-3-4-4-4-5-4-6-4-7-5-6-7-8-9">
           СОДЕРЖАНИЕ:
@@ -601,9 +601,9 @@
               <div class="div__frame-1000005873">
                 <div class="div__div3">Важная информация</div>
                 <div class="div__frame-1000006053">
-                  <div class="div__div4">Политика конфиденциальности</div>
-                  <div class="div__div4">Пользовательское соглашение</div>
-                  <div class="div__div4">Политика возврата средств</div>
+                  <a class="div__div4" href="{% url 'politconf' %}">Политика конфиденциальности</a>
+                  <a class="div__div4" href="{% url 'usersogl' %}">Пользовательское соглашение</a>
+                  <a class="div__div4" href="{% url 'moneyback' %}">Политика возврата средств</a>
                 </div>
               </div>
               <div class="div__frame-10000058752">

--- a/robux_withdraw_pc/index.html
+++ b/robux_withdraw_pc/index.html
@@ -147,9 +147,9 @@
               <div class="div__frame-1000005873">
                 <div class="div__div6">Важная информация</div>
                 <div class="div__frame-1000006053">
-                  <div class="div__div7">Политика конфиденциальности</div>
-                  <div class="div__div7">Пользовательское соглашение</div>
-                  <div class="div__div7">Политика возврата средств</div>
+                  <a class="div__div7" href="{% url 'politconf' %}">Политика конфиденциальности</a>
+                  <a class="div__div7" href="{% url 'usersogl' %}">Пользовательское соглашение</a>
+                  <a class="div__div7" href="{% url 'moneyback' %}">Политика возврата средств</a>
                 </div>
               </div>
               <div class="div__frame-10000058752">


### PR DESCRIPTION
## Summary
- convert policy text blocks in multiple templates to anchors
- link policies in popup agreement

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871a8f0431c832db7652fa074d2d198