### PR TITLE
Prevent buying without valid gamepass

### DIFF
--- a/robux_gamepasses_pc/index.html
+++ b/robux_gamepasses_pc/index.html
@@ -138,7 +138,7 @@
   <div class="game-pass">
     <div class="game-pass__frame-1000005835">
       <div class="game-pass__frame-1000005844">
-        <a class="game-pass__button" href="http://rbxkingdom.com/buy/">
+        <a class="game-pass__button{% if not allow_proceed %} disabled{% endif %}" {% if allow_proceed %}href="http://rbxkingdom.com/buy/"{% else %}href="#"{% endif %}>
           <div class="game-pass__heading-2">Я создал Game Pass</div>
         </a>
         <div class="game-pass__frame-1000005980">

--- a/robux_gamepasses_pc/style.css
+++ b/robux_gamepasses_pc/style.css
@@ -37,6 +37,10 @@
   left: 7.5rem;
   top: 56rem;
 }
+.game-pass__button.disabled {
+  opacity: 0.5;
+  pointer-events: none;
+}
 .game-pass__heading-2 {
   color: #ffffff;
   text-align: center;


### PR DESCRIPTION
## Summary
- don't allow advancing to payment until a gamepass with the expected price exists and regional pricing is disabled
- disable the *I created Game Pass* button when the requirements aren't met

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6871ae953a64832d81a6ee61c442c585