### PR TITLE
Add account menu to all pages

### DIFF
--- a/robux_back_money_pc/index.html
+++ b/robux_back_money_pc/index.html
@@ -182,16 +182,51 @@
         </div>
       </div>
     </div>
-    <div class="div__frame-1000005958">
+    <a id="account-button" class="div__frame-1000005958 button" href="#">
       <img class="div__image" src="http://rbxkingdom.com/robux_back_money_pc/image0.png" />
       <div class="div__frame-1000005915">
         <div class="div__gefzyy-123">gefzyy_123</div>
         <div class="div__div10">Перейти в профиль</div>
       </div>
       <img class="div__vector9" src="http://rbxkingdom.com/robux_back_money_pc/vector8.svg" />
-    </div>
+    </a>
   </div>
+          <div id="account-menu" class="account-menu">
+            <a class="account-menu-item account-menu-item--stats" href="http://rbxkingdom.com/account/">
+              <img class="account-menu-icon" src="http://rbxkingdom.com/robux_account_pc/group0_2.svg" />
+              <div class="account-menu-text">Статистика аккаунта</div>
+            </a>
+            <a class="account-menu-item account-menu-item--purchases" href="http://rbxkingdom.com/buy/">
+              <img class="account-menu-icon" src="http://rbxkingdom.com/robux_account_pc/shopping-cart-svgrepo-com-10_2.svg" />
+              <div class="account-menu-text">Мои покупки</div>
+            </a>
+            <a class="account-menu-item account-menu-item--bonus" href="http://rbxkingdom.com/bonus/">
+              <img class="account-menu-icon" src="http://rbxkingdom.com/robux_account_pc/svg0_2.svg" />
+              <div class="account-menu-text">Бонусы</div>
+            </a>
+            <a class="account-menu-item account-menu-item--logout" href="http://rbxkingdom.com/logout/">
+              <img class="account-menu-icon" src="http://rbxkingdom.com/robux_account_pc/icon-left0_2.svg" />
+              <div class="account-menu-text">Выйти</div>
+            </a>
+          </div>
 
 </body>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const accountBtn = document.getElementById('account-button');
+      const menu = document.getElementById('account-menu');
+
+      accountBtn.addEventListener('click', (e) => {
+        e.preventDefault();
+        menu.classList.toggle('show');
+      });
+
+      document.addEventListener('click', (e) => {
+        if (!accountBtn.contains(e.target) && !menu.contains(e.target)) {
+          menu.classList.remove('show');
+        }
+      });
+    });
+  </script>
 
 </html>

--- a/robux_back_money_pc/style.css
+++ b/robux_back_money_pc/style.css
@@ -791,3 +791,67 @@
   transform: translate(-0.047rem, -0.047rem);
   overflow: visible;
 }
+\n
+.account-menu {
+  transition: .3s;
+  position: absolute;
+  left: 141.2rem;
+  overflow: hidden;
+  top: 12rem;
+  width: 23.3rem;
+  background-color: #2e313d;
+  border-radius: 10px;
+  opacity: 0;
+  transform: translateY(-10px);
+  visibility: hidden;
+  transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease;
+  flex-direction: column;
+  z-index: 1000;
+  padding: 0;
+}
+#account-menu.show {
+  opacity: 1;
+  transform: translateY(0);
+  visibility: visible;
+}
+.account-menu-item {
+  display: flex;
+  flex-direction: row;
+  gap: 0.9rem;
+  align-items: center;
+  padding: 1rem 2rem;
+  color: #798cb4;
+  font-family: "Inter-Medium", sans-serif;
+  font-size: 1.4rem;
+  line-height: 2.326rem;
+  font-weight: 500;
+  text-decoration: none;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+.account-menu-item img {
+  width: 1.8rem;
+  height: 1.8rem;
+}
+.account-menu-item--stats:hover {
+  background-color: #3FC28C;
+  color: #ffffff;
+}
+.account-menu-item--purchases:hover {
+  background-color: #CF6EFF;
+  color: #ffffff;
+}
+.account-menu-item--bonus:hover {
+  background-color: #F7A013;
+  color: #ffffff;
+}
+.account-menu-item--logout:hover {
+  background-color: #E56B6B;
+  color: #ffffff;
+}
+.account-menu-icon {
+  transition: filter 0.2s ease;
+}
+/* Белая иконка при ховере */
+.account-menu-item:hover .account-menu-icon {
+  filter: brightness(0) invert(1);
+}

--- a/robux_bonus_pc/index.html
+++ b/robux_bonus_pc/index.html
@@ -662,7 +662,7 @@
 
           </style>
       <div class="div__frame-1000002206">
-        <a class="div__frame-1000005958 button" href="http://rbxkingdom.com/account/">
+        <a id="account-button" class="div__frame-1000005958 button" href="#">
             <img class="div__image2" src="{{ profile.image_url }}" />
             <div class="div__frame-1000005915">
               <div class="div__gefzyy-1232">{{ profile.username }}</div>
@@ -671,6 +671,24 @@
             <img class="div__vector9" src="http://rbxkingdom.com/robux_account_pc/vector8.svg" />
           </a>
         <div class="div__frame-48095932">
+          <div id="account-menu" class="account-menu">
+            <a class="account-menu-item account-menu-item--stats" href="http://rbxkingdom.com/account/">
+              <img class="account-menu-icon" src="http://rbxkingdom.com/robux_account_pc/group0_2.svg" />
+              <div class="account-menu-text">Статистика аккаунта</div>
+            </a>
+            <a class="account-menu-item account-menu-item--purchases" href="http://rbxkingdom.com/buy/">
+              <img class="account-menu-icon" src="http://rbxkingdom.com/robux_account_pc/shopping-cart-svgrepo-com-10_2.svg" />
+              <div class="account-menu-text">Мои покупки</div>
+            </a>
+            <a class="account-menu-item account-menu-item--bonus" href="http://rbxkingdom.com/bonus/">
+              <img class="account-menu-icon" src="http://rbxkingdom.com/robux_account_pc/svg0_2.svg" />
+              <div class="account-menu-text">Бонусы</div>
+            </a>
+            <a class="account-menu-item account-menu-item--logout" href="http://rbxkingdom.com/logout/">
+              <img class="account-menu-icon" src="http://rbxkingdom.com/robux_account_pc/icon-left0_2.svg" />
+              <div class="account-menu-text">Выйти</div>
+            </a>
+          </div>
           <div class="div__frame-48095930">
             <a class="div__frame-48095926" href="http://rbxkingdom.com/">
               <div class="div__div27">Купить робуксы</div>
@@ -724,4 +742,21 @@
   </div>
   
 </body>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const accountBtn = document.getElementById('account-button');
+      const menu = document.getElementById('account-menu');
+
+      accountBtn.addEventListener('click', (e) => {
+        e.preventDefault();
+        menu.classList.toggle('show');
+      });
+
+      document.addEventListener('click', (e) => {
+        if (!accountBtn.contains(e.target) && !menu.contains(e.target)) {
+          menu.classList.remove('show');
+        }
+      });
+    });
+  </script>
 </html>

--- a/robux_bonus_pc/style.css
+++ b/robux_bonus_pc/style.css
@@ -2038,3 +2038,67 @@
   opacity: 0.6;
   pointer-events: none;
 }
+\n
+.account-menu {
+  transition: .3s;
+  position: absolute;
+  left: 141.2rem;
+  overflow: hidden;
+  top: 12rem;
+  width: 23.3rem;
+  background-color: #2e313d;
+  border-radius: 10px;
+  opacity: 0;
+  transform: translateY(-10px);
+  visibility: hidden;
+  transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease;
+  flex-direction: column;
+  z-index: 1000;
+  padding: 0;
+}
+#account-menu.show {
+  opacity: 1;
+  transform: translateY(0);
+  visibility: visible;
+}
+.account-menu-item {
+  display: flex;
+  flex-direction: row;
+  gap: 0.9rem;
+  align-items: center;
+  padding: 1rem 2rem;
+  color: #798cb4;
+  font-family: "Inter-Medium", sans-serif;
+  font-size: 1.4rem;
+  line-height: 2.326rem;
+  font-weight: 500;
+  text-decoration: none;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+.account-menu-item img {
+  width: 1.8rem;
+  height: 1.8rem;
+}
+.account-menu-item--stats:hover {
+  background-color: #3FC28C;
+  color: #ffffff;
+}
+.account-menu-item--purchases:hover {
+  background-color: #CF6EFF;
+  color: #ffffff;
+}
+.account-menu-item--bonus:hover {
+  background-color: #F7A013;
+  color: #ffffff;
+}
+.account-menu-item--logout:hover {
+  background-color: #E56B6B;
+  color: #ffffff;
+}
+.account-menu-icon {
+  transition: filter 0.2s ease;
+}
+/* Белая иконка при ховере */
+.account-menu-item:hover .account-menu-icon {
+  filter: brightness(0) invert(1);
+}

--- a/robux_buy_pc/index.html
+++ b/robux_buy_pc/index.html
@@ -268,15 +268,50 @@
         </div>
       </div>
     </div>
-    <div class="div__frame-1000005958">
+    <a id="account-button" class="div__frame-1000005958 button" href="#">
       <img class="div__image2" src="{{ profile.image_url }}" />
       <div class="div__frame-1000005915">
         <div class="div__gefzyy-123">{{ profile.username }}</div>
         <div class="div__div13">Перейти в профиль</div>
       </div>
       <img class="div__vector9" src="http://rbxkingdom.com/robux_buy_pc/vector8.svg" />
-    </div>
+    </a>
   </div>
+          <div id="account-menu" class="account-menu">
+            <a class="account-menu-item account-menu-item--stats" href="http://rbxkingdom.com/account/">
+              <img class="account-menu-icon" src="http://rbxkingdom.com/robux_account_pc/group0_2.svg" />
+              <div class="account-menu-text">Статистика аккаунта</div>
+            </a>
+            <a class="account-menu-item account-menu-item--purchases" href="http://rbxkingdom.com/buy/">
+              <img class="account-menu-icon" src="http://rbxkingdom.com/robux_account_pc/shopping-cart-svgrepo-com-10_2.svg" />
+              <div class="account-menu-text">Мои покупки</div>
+            </a>
+            <a class="account-menu-item account-menu-item--bonus" href="http://rbxkingdom.com/bonus/">
+              <img class="account-menu-icon" src="http://rbxkingdom.com/robux_account_pc/svg0_2.svg" />
+              <div class="account-menu-text">Бонусы</div>
+            </a>
+            <a class="account-menu-item account-menu-item--logout" href="http://rbxkingdom.com/logout/">
+              <img class="account-menu-icon" src="http://rbxkingdom.com/robux_account_pc/icon-left0_2.svg" />
+              <div class="account-menu-text">Выйти</div>
+            </a>
+          </div>
   
 </body>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const accountBtn = document.getElementById('account-button');
+      const menu = document.getElementById('account-menu');
+
+      accountBtn.addEventListener('click', (e) => {
+        e.preventDefault();
+        menu.classList.toggle('show');
+      });
+
+      document.addEventListener('click', (e) => {
+        if (!accountBtn.contains(e.target) && !menu.contains(e.target)) {
+          menu.classList.remove('show');
+        }
+      });
+    });
+  </script>
 </html>

--- a/robux_buy_pc/style.css
+++ b/robux_buy_pc/style.css
@@ -1384,3 +1384,67 @@
   transform: translate(-0.047rem, -0.047rem);
   overflow: visible;
 }
+\n
+.account-menu {
+  transition: .3s;
+  position: absolute;
+  left: 141.2rem;
+  overflow: hidden;
+  top: 12rem;
+  width: 23.3rem;
+  background-color: #2e313d;
+  border-radius: 10px;
+  opacity: 0;
+  transform: translateY(-10px);
+  visibility: hidden;
+  transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease;
+  flex-direction: column;
+  z-index: 1000;
+  padding: 0;
+}
+#account-menu.show {
+  opacity: 1;
+  transform: translateY(0);
+  visibility: visible;
+}
+.account-menu-item {
+  display: flex;
+  flex-direction: row;
+  gap: 0.9rem;
+  align-items: center;
+  padding: 1rem 2rem;
+  color: #798cb4;
+  font-family: "Inter-Medium", sans-serif;
+  font-size: 1.4rem;
+  line-height: 2.326rem;
+  font-weight: 500;
+  text-decoration: none;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+.account-menu-item img {
+  width: 1.8rem;
+  height: 1.8rem;
+}
+.account-menu-item--stats:hover {
+  background-color: #3FC28C;
+  color: #ffffff;
+}
+.account-menu-item--purchases:hover {
+  background-color: #CF6EFF;
+  color: #ffffff;
+}
+.account-menu-item--bonus:hover {
+  background-color: #F7A013;
+  color: #ffffff;
+}
+.account-menu-item--logout:hover {
+  background-color: #E56B6B;
+  color: #ffffff;
+}
+.account-menu-icon {
+  transition: filter 0.2s ease;
+}
+/* Белая иконка при ховере */
+.account-menu-item:hover .account-menu-icon {
+  filter: brightness(0) invert(1);
+}

--- a/robux_check_acc_pc/index.html
+++ b/robux_check_acc_pc/index.html
@@ -224,17 +224,52 @@
         </div>
       </div>
     </div>
-    <div class="div__frame-1000005958">
+    <a id="account-button" class="div__frame-1000005958 button" href="#">
       <img class="div__image2" src="{{ profile.image_url }}" />
       <div class="div__frame-1000005915">
         <div class="div__gefzyy-1232">{{ profile.username }}</div>
         <div class="div__div12">Перейти в профиль</div>
       </div>
       <img class="div__vector9" src="http://rbxkingdom.com/robux_check_acc_pc/vector8.svg" />
-    </div>
+    </a>
   </div>
+          <div id="account-menu" class="account-menu">
+            <a class="account-menu-item account-menu-item--stats" href="http://rbxkingdom.com/account/">
+              <img class="account-menu-icon" src="http://rbxkingdom.com/robux_account_pc/group0_2.svg" />
+              <div class="account-menu-text">Статистика аккаунта</div>
+            </a>
+            <a class="account-menu-item account-menu-item--purchases" href="http://rbxkingdom.com/buy/">
+              <img class="account-menu-icon" src="http://rbxkingdom.com/robux_account_pc/shopping-cart-svgrepo-com-10_2.svg" />
+              <div class="account-menu-text">Мои покупки</div>
+            </a>
+            <a class="account-menu-item account-menu-item--bonus" href="http://rbxkingdom.com/bonus/">
+              <img class="account-menu-icon" src="http://rbxkingdom.com/robux_account_pc/svg0_2.svg" />
+              <div class="account-menu-text">Бонусы</div>
+            </a>
+            <a class="account-menu-item account-menu-item--logout" href="http://rbxkingdom.com/logout/">
+              <img class="account-menu-icon" src="http://rbxkingdom.com/robux_account_pc/icon-left0_2.svg" />
+              <div class="account-menu-text">Выйти</div>
+            </a>
+          </div>
   
 </body>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const accountBtn = document.getElementById('account-button');
+      const menu = document.getElementById('account-menu');
+
+      accountBtn.addEventListener('click', (e) => {
+        e.preventDefault();
+        menu.classList.toggle('show');
+      });
+
+      document.addEventListener('click', (e) => {
+        if (!accountBtn.contains(e.target) && !menu.contains(e.target)) {
+          menu.classList.remove('show');
+        }
+      });
+    });
+  </script>
 <script>
   document.addEventListener('DOMContentLoaded', function() {
     // Находим контейнер с иконкой и ником

--- a/robux_check_acc_pc/style.css
+++ b/robux_check_acc_pc/style.css
@@ -1108,3 +1108,67 @@
   transform: translate(-0.047rem, -0.047rem);
   overflow: visible;
 }
+\n
+.account-menu {
+  transition: .3s;
+  position: absolute;
+  left: 141.2rem;
+  overflow: hidden;
+  top: 12rem;
+  width: 23.3rem;
+  background-color: #2e313d;
+  border-radius: 10px;
+  opacity: 0;
+  transform: translateY(-10px);
+  visibility: hidden;
+  transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease;
+  flex-direction: column;
+  z-index: 1000;
+  padding: 0;
+}
+#account-menu.show {
+  opacity: 1;
+  transform: translateY(0);
+  visibility: visible;
+}
+.account-menu-item {
+  display: flex;
+  flex-direction: row;
+  gap: 0.9rem;
+  align-items: center;
+  padding: 1rem 2rem;
+  color: #798cb4;
+  font-family: "Inter-Medium", sans-serif;
+  font-size: 1.4rem;
+  line-height: 2.326rem;
+  font-weight: 500;
+  text-decoration: none;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+.account-menu-item img {
+  width: 1.8rem;
+  height: 1.8rem;
+}
+.account-menu-item--stats:hover {
+  background-color: #3FC28C;
+  color: #ffffff;
+}
+.account-menu-item--purchases:hover {
+  background-color: #CF6EFF;
+  color: #ffffff;
+}
+.account-menu-item--bonus:hover {
+  background-color: #F7A013;
+  color: #ffffff;
+}
+.account-menu-item--logout:hover {
+  background-color: #E56B6B;
+  color: #ffffff;
+}
+.account-menu-icon {
+  transition: filter 0.2s ease;
+}
+/* Белая иконка при ховере */
+.account-menu-item:hover .account-menu-icon {
+  filter: brightness(0) invert(1);
+}

--- a/robux_gamepasses_pc/index.html
+++ b/robux_gamepasses_pc/index.html
@@ -417,15 +417,50 @@ document.addEventListener('DOMContentLoaded', () => {
         </div>
       </div>
     </div>
-    <div class="game-pass__frame-1000005958">
+    <a id="account-button" class="game-pass__frame-1000005958 button" href="#">
       <img class="game-pass__image" src="{{ profile.image_url }}" />
       <div class="game-pass__frame-1000005915">
         <div class="game-pass__gefzyy-123">{{ profile.username }}</div>
         <div class="game-pass__div8">Перейти в профиль</div>
       </div>
       <img class="game-pass__vector10" src="http://rbxkingdom.com/robux_gamepasses_pc/vector9.svg" />
-    </div>
+    </a>
   </div>
+          <div id="account-menu" class="account-menu">
+            <a class="account-menu-item account-menu-item--stats" href="http://rbxkingdom.com/account/">
+              <img class="account-menu-icon" src="http://rbxkingdom.com/robux_account_pc/group0_2.svg" />
+              <div class="account-menu-text">Статистика аккаунта</div>
+            </a>
+            <a class="account-menu-item account-menu-item--purchases" href="http://rbxkingdom.com/buy/">
+              <img class="account-menu-icon" src="http://rbxkingdom.com/robux_account_pc/shopping-cart-svgrepo-com-10_2.svg" />
+              <div class="account-menu-text">Мои покупки</div>
+            </a>
+            <a class="account-menu-item account-menu-item--bonus" href="http://rbxkingdom.com/bonus/">
+              <img class="account-menu-icon" src="http://rbxkingdom.com/robux_account_pc/svg0_2.svg" />
+              <div class="account-menu-text">Бонусы</div>
+            </a>
+            <a class="account-menu-item account-menu-item--logout" href="http://rbxkingdom.com/logout/">
+              <img class="account-menu-icon" src="http://rbxkingdom.com/robux_account_pc/icon-left0_2.svg" />
+              <div class="account-menu-text">Выйти</div>
+            </a>
+          </div>
   
 </body>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const accountBtn = document.getElementById('account-button');
+      const menu = document.getElementById('account-menu');
+
+      accountBtn.addEventListener('click', (e) => {
+        e.preventDefault();
+        menu.classList.toggle('show');
+      });
+
+      document.addEventListener('click', (e) => {
+        if (!accountBtn.contains(e.target) && !menu.contains(e.target)) {
+          menu.classList.remove('show');
+        }
+      });
+    });
+  </script>
 </html>

--- a/robux_gamepasses_pc/style.css
+++ b/robux_gamepasses_pc/style.css
@@ -1000,3 +1000,67 @@
   font-family: "Wix Madefor Display", sans-serif;
   font-size: 1.6rem;
 }
+\n
+.account-menu {
+  transition: .3s;
+  position: absolute;
+  left: 141.2rem;
+  overflow: hidden;
+  top: 12rem;
+  width: 23.3rem;
+  background-color: #2e313d;
+  border-radius: 10px;
+  opacity: 0;
+  transform: translateY(-10px);
+  visibility: hidden;
+  transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease;
+  flex-direction: column;
+  z-index: 1000;
+  padding: 0;
+}
+#account-menu.show {
+  opacity: 1;
+  transform: translateY(0);
+  visibility: visible;
+}
+.account-menu-item {
+  display: flex;
+  flex-direction: row;
+  gap: 0.9rem;
+  align-items: center;
+  padding: 1rem 2rem;
+  color: #798cb4;
+  font-family: "Inter-Medium", sans-serif;
+  font-size: 1.4rem;
+  line-height: 2.326rem;
+  font-weight: 500;
+  text-decoration: none;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+.account-menu-item img {
+  width: 1.8rem;
+  height: 1.8rem;
+}
+.account-menu-item--stats:hover {
+  background-color: #3FC28C;
+  color: #ffffff;
+}
+.account-menu-item--purchases:hover {
+  background-color: #CF6EFF;
+  color: #ffffff;
+}
+.account-menu-item--bonus:hover {
+  background-color: #F7A013;
+  color: #ffffff;
+}
+.account-menu-item--logout:hover {
+  background-color: #E56B6B;
+  color: #ffffff;
+}
+.account-menu-icon {
+  transition: filter 0.2s ease;
+}
+/* Белая иконка при ховере */
+.account-menu-item:hover .account-menu-icon {
+  filter: brightness(0) invert(1);
+}

--- a/robux_head_pc/index.html
+++ b/robux_head_pc/index.html
@@ -358,7 +358,7 @@
             }
 
           </style>
-          <a class="div__frame-1000005958 button" href="http://rbxkingdom.com/account/">
+          <a id="account-button" class="div__frame-1000005958 button" href="#">
             <img class="div__image2" src="{{ profile.image_url }}" />
             <div class="div__frame-1000005915">
               <div class="div__gefzyy-1232">{{ profile.username }}</div>
@@ -367,6 +367,24 @@
             <img class="div__vector9" src="http://rbxkingdom.com/robux_account_pc/vector8.svg" />
           </a>
 
+          <div id="account-menu" class="account-menu">
+            <a class="account-menu-item account-menu-item--stats" href="http://rbxkingdom.com/account/">
+              <img class="account-menu-icon" src="http://rbxkingdom.com/robux_account_pc/group0_2.svg" />
+              <div class="account-menu-text">Статистика аккаунта</div>
+            </a>
+            <a class="account-menu-item account-menu-item--purchases" href="http://rbxkingdom.com/buy/">
+              <img class="account-menu-icon" src="http://rbxkingdom.com/robux_account_pc/shopping-cart-svgrepo-com-10_2.svg" />
+              <div class="account-menu-text">Мои покупки</div>
+            </a>
+            <a class="account-menu-item account-menu-item--bonus" href="http://rbxkingdom.com/bonus/">
+              <img class="account-menu-icon" src="http://rbxkingdom.com/robux_account_pc/svg0_2.svg" />
+              <div class="account-menu-text">Бонусы</div>
+            </a>
+            <a class="account-menu-item account-menu-item--logout" href="http://rbxkingdom.com/logout/">
+              <img class="account-menu-icon" src="http://rbxkingdom.com/robux_account_pc/icon-left0_2.svg" />
+              <div class="account-menu-text">Выйти</div>
+            </a>
+          </div>
           {% endif %}
           
           
@@ -1135,6 +1153,23 @@ document.addEventListener('DOMContentLoaded', () => {
 
 
 </body>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const accountBtn = document.getElementById('account-button');
+      const menu = document.getElementById('account-menu');
+
+      accountBtn.addEventListener('click', (e) => {
+        e.preventDefault();
+        menu.classList.toggle('show');
+      });
+
+      document.addEventListener('click', (e) => {
+        if (!accountBtn.contains(e.target) && !menu.contains(e.target)) {
+          menu.classList.remove('show');
+        }
+      });
+    });
+  </script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/@fancyapps/ui@5.0/dist/fancybox/fancybox.umd.js"></script>
 

--- a/robux_head_pc/style.css
+++ b/robux_head_pc/style.css
@@ -3297,3 +3297,67 @@ a:hover {
       width: 4.079rem;
       height: 4.079rem;
     }
+\n
+.account-menu {
+  transition: .3s;
+  position: absolute;
+  left: 141.2rem;
+  overflow: hidden;
+  top: 12rem;
+  width: 23.3rem;
+  background-color: #2e313d;
+  border-radius: 10px;
+  opacity: 0;
+  transform: translateY(-10px);
+  visibility: hidden;
+  transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease;
+  flex-direction: column;
+  z-index: 1000;
+  padding: 0;
+}
+#account-menu.show {
+  opacity: 1;
+  transform: translateY(0);
+  visibility: visible;
+}
+.account-menu-item {
+  display: flex;
+  flex-direction: row;
+  gap: 0.9rem;
+  align-items: center;
+  padding: 1rem 2rem;
+  color: #798cb4;
+  font-family: "Inter-Medium", sans-serif;
+  font-size: 1.4rem;
+  line-height: 2.326rem;
+  font-weight: 500;
+  text-decoration: none;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+.account-menu-item img {
+  width: 1.8rem;
+  height: 1.8rem;
+}
+.account-menu-item--stats:hover {
+  background-color: #3FC28C;
+  color: #ffffff;
+}
+.account-menu-item--purchases:hover {
+  background-color: #CF6EFF;
+  color: #ffffff;
+}
+.account-menu-item--bonus:hover {
+  background-color: #F7A013;
+  color: #ffffff;
+}
+.account-menu-item--logout:hover {
+  background-color: #E56B6B;
+  color: #ffffff;
+}
+.account-menu-icon {
+  transition: filter 0.2s ease;
+}
+/* Белая иконка при ховере */
+.account-menu-item:hover .account-menu-icon {
+  filter: brightness(0) invert(1);
+}

--- a/robux_places_pc/index.html
+++ b/robux_places_pc/index.html
@@ -213,15 +213,33 @@
         </div>
       </div>
     </div>
-    <div class="place__frame-1000005958">
+    <a id="account-button" class="place__frame-1000005958 button" href="#">
       <img class="place__image" src="{{ profile.image_url }}" />
       <div class="place__frame-1000005915">
         <div class="place__gefzyy-123">{{ profile.username }}</div>
         <div class="place__div8">Перейти в профиль</div>
       </div>
       <img class="place__vector9" src="http://rbxkingdom.com/robux_places_pc/vector8.svg" />
-    </div>
+    </a>
   </div>
+          <div id="account-menu" class="account-menu">
+            <a class="account-menu-item account-menu-item--stats" href="http://rbxkingdom.com/account/">
+              <img class="account-menu-icon" src="http://rbxkingdom.com/robux_account_pc/group0_2.svg" />
+              <div class="account-menu-text">Статистика аккаунта</div>
+            </a>
+            <a class="account-menu-item account-menu-item--purchases" href="http://rbxkingdom.com/buy/">
+              <img class="account-menu-icon" src="http://rbxkingdom.com/robux_account_pc/shopping-cart-svgrepo-com-10_2.svg" />
+              <div class="account-menu-text">Мои покупки</div>
+            </a>
+            <a class="account-menu-item account-menu-item--bonus" href="http://rbxkingdom.com/bonus/">
+              <img class="account-menu-icon" src="http://rbxkingdom.com/robux_account_pc/svg0_2.svg" />
+              <div class="account-menu-text">Бонусы</div>
+            </a>
+            <a class="account-menu-item account-menu-item--logout" href="http://rbxkingdom.com/logout/">
+              <img class="account-menu-icon" src="http://rbxkingdom.com/robux_account_pc/icon-left0_2.svg" />
+              <div class="account-menu-text">Выйти</div>
+            </a>
+          </div>
   
 <script>
 document.addEventListener("DOMContentLoaded", function() {
@@ -253,4 +271,21 @@ document.addEventListener("DOMContentLoaded", function() {
 });
 </script>
 </body>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const accountBtn = document.getElementById('account-button');
+      const menu = document.getElementById('account-menu');
+
+      accountBtn.addEventListener('click', (e) => {
+        e.preventDefault();
+        menu.classList.toggle('show');
+      });
+
+      document.addEventListener('click', (e) => {
+        if (!accountBtn.contains(e.target) && !menu.contains(e.target)) {
+          menu.classList.remove('show');
+        }
+      });
+    });
+  </script>
 </html>

--- a/robux_places_pc/style.css
+++ b/robux_places_pc/style.css
@@ -942,3 +942,67 @@
 .place__frame-1000005982.selected .place__checkmark {
   display: block;
 }
+\n
+.account-menu {
+  transition: .3s;
+  position: absolute;
+  left: 141.2rem;
+  overflow: hidden;
+  top: 12rem;
+  width: 23.3rem;
+  background-color: #2e313d;
+  border-radius: 10px;
+  opacity: 0;
+  transform: translateY(-10px);
+  visibility: hidden;
+  transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease;
+  flex-direction: column;
+  z-index: 1000;
+  padding: 0;
+}
+#account-menu.show {
+  opacity: 1;
+  transform: translateY(0);
+  visibility: visible;
+}
+.account-menu-item {
+  display: flex;
+  flex-direction: row;
+  gap: 0.9rem;
+  align-items: center;
+  padding: 1rem 2rem;
+  color: #798cb4;
+  font-family: "Inter-Medium", sans-serif;
+  font-size: 1.4rem;
+  line-height: 2.326rem;
+  font-weight: 500;
+  text-decoration: none;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+.account-menu-item img {
+  width: 1.8rem;
+  height: 1.8rem;
+}
+.account-menu-item--stats:hover {
+  background-color: #3FC28C;
+  color: #ffffff;
+}
+.account-menu-item--purchases:hover {
+  background-color: #CF6EFF;
+  color: #ffffff;
+}
+.account-menu-item--bonus:hover {
+  background-color: #F7A013;
+  color: #ffffff;
+}
+.account-menu-item--logout:hover {
+  background-color: #E56B6B;
+  color: #ffffff;
+}
+.account-menu-icon {
+  transition: filter 0.2s ease;
+}
+/* Белая иконка при ховере */
+.account-menu-item:hover .account-menu-icon {
+  filter: brightness(0) invert(1);
+}

--- a/robux_politconf_pc/index.html
+++ b/robux_politconf_pc/index.html
@@ -539,15 +539,50 @@
         </div>
       </div>
     </div>
-    <div class="div__frame-1000005958">
+    <a id="account-button" class="div__frame-1000005958 button" href="#">
       <img class="div__image" src="http://rbxkingdom.com/robux_politconf_pc/image0.png" />
       <div class="div__frame-1000005915">
         <div class="div__gefzyy-123">gefzyy_123</div>
         <div class="div__div10">Перейти в профиль</div>
       </div>
       <img class="div__vector9" src="http://rbxkingdom.com/robux_politconf_pc/vector8.svg" />
-    </div>
+    </a>
   </div>
+          <div id="account-menu" class="account-menu">
+            <a class="account-menu-item account-menu-item--stats" href="http://rbxkingdom.com/account/">
+              <img class="account-menu-icon" src="http://rbxkingdom.com/robux_account_pc/group0_2.svg" />
+              <div class="account-menu-text">Статистика аккаунта</div>
+            </a>
+            <a class="account-menu-item account-menu-item--purchases" href="http://rbxkingdom.com/buy/">
+              <img class="account-menu-icon" src="http://rbxkingdom.com/robux_account_pc/shopping-cart-svgrepo-com-10_2.svg" />
+              <div class="account-menu-text">Мои покупки</div>
+            </a>
+            <a class="account-menu-item account-menu-item--bonus" href="http://rbxkingdom.com/bonus/">
+              <img class="account-menu-icon" src="http://rbxkingdom.com/robux_account_pc/svg0_2.svg" />
+              <div class="account-menu-text">Бонусы</div>
+            </a>
+            <a class="account-menu-item account-menu-item--logout" href="http://rbxkingdom.com/logout/">
+              <img class="account-menu-icon" src="http://rbxkingdom.com/robux_account_pc/icon-left0_2.svg" />
+              <div class="account-menu-text">Выйти</div>
+            </a>
+          </div>
   
 </body>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const accountBtn = document.getElementById('account-button');
+      const menu = document.getElementById('account-menu');
+
+      accountBtn.addEventListener('click', (e) => {
+        e.preventDefault();
+        menu.classList.toggle('show');
+      });
+
+      document.addEventListener('click', (e) => {
+        if (!accountBtn.contains(e.target) && !menu.contains(e.target)) {
+          menu.classList.remove('show');
+        }
+      });
+    });
+  </script>
 </html>

--- a/robux_politconf_pc/style.css
+++ b/robux_politconf_pc/style.css
@@ -800,3 +800,67 @@
   transform: translate(-0.047rem, -0.047rem);
   overflow: visible;
 }
+\n
+.account-menu {
+  transition: .3s;
+  position: absolute;
+  left: 141.2rem;
+  overflow: hidden;
+  top: 12rem;
+  width: 23.3rem;
+  background-color: #2e313d;
+  border-radius: 10px;
+  opacity: 0;
+  transform: translateY(-10px);
+  visibility: hidden;
+  transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease;
+  flex-direction: column;
+  z-index: 1000;
+  padding: 0;
+}
+#account-menu.show {
+  opacity: 1;
+  transform: translateY(0);
+  visibility: visible;
+}
+.account-menu-item {
+  display: flex;
+  flex-direction: row;
+  gap: 0.9rem;
+  align-items: center;
+  padding: 1rem 2rem;
+  color: #798cb4;
+  font-family: "Inter-Medium", sans-serif;
+  font-size: 1.4rem;
+  line-height: 2.326rem;
+  font-weight: 500;
+  text-decoration: none;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+.account-menu-item img {
+  width: 1.8rem;
+  height: 1.8rem;
+}
+.account-menu-item--stats:hover {
+  background-color: #3FC28C;
+  color: #ffffff;
+}
+.account-menu-item--purchases:hover {
+  background-color: #CF6EFF;
+  color: #ffffff;
+}
+.account-menu-item--bonus:hover {
+  background-color: #F7A013;
+  color: #ffffff;
+}
+.account-menu-item--logout:hover {
+  background-color: #E56B6B;
+  color: #ffffff;
+}
+.account-menu-icon {
+  transition: filter 0.2s ease;
+}
+/* Белая иконка при ховере */
+.account-menu-item:hover .account-menu-icon {
+  filter: brightness(0) invert(1);
+}

--- a/robux_user_agree/index.html
+++ b/robux_user_agree/index.html
@@ -714,15 +714,50 @@
         </div>
       </div>
     </div>
-    <div class="div__frame-1000005958">
+    <a id="account-button" class="div__frame-1000005958 button" href="#">
       <img class="div__image" src="http://rbxkingdom.com/robux_user_agree/image0.png" />
       <div class="div__frame-1000005915">
         <div class="div__gefzyy-123">gefzyy_123</div>
         <div class="div__div10">Перейти в профиль</div>
       </div>
       <img class="div__vector9" src="http://rbxkingdom.com/robux_user_agree/vector8.svg" />
-    </div>
+    </a>
   </div>
+          <div id="account-menu" class="account-menu">
+            <a class="account-menu-item account-menu-item--stats" href="http://rbxkingdom.com/account/">
+              <img class="account-menu-icon" src="http://rbxkingdom.com/robux_account_pc/group0_2.svg" />
+              <div class="account-menu-text">Статистика аккаунта</div>
+            </a>
+            <a class="account-menu-item account-menu-item--purchases" href="http://rbxkingdom.com/buy/">
+              <img class="account-menu-icon" src="http://rbxkingdom.com/robux_account_pc/shopping-cart-svgrepo-com-10_2.svg" />
+              <div class="account-menu-text">Мои покупки</div>
+            </a>
+            <a class="account-menu-item account-menu-item--bonus" href="http://rbxkingdom.com/bonus/">
+              <img class="account-menu-icon" src="http://rbxkingdom.com/robux_account_pc/svg0_2.svg" />
+              <div class="account-menu-text">Бонусы</div>
+            </a>
+            <a class="account-menu-item account-menu-item--logout" href="http://rbxkingdom.com/logout/">
+              <img class="account-menu-icon" src="http://rbxkingdom.com/robux_account_pc/icon-left0_2.svg" />
+              <div class="account-menu-text">Выйти</div>
+            </a>
+          </div>
   
 </body>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const accountBtn = document.getElementById('account-button');
+      const menu = document.getElementById('account-menu');
+
+      accountBtn.addEventListener('click', (e) => {
+        e.preventDefault();
+        menu.classList.toggle('show');
+      });
+
+      document.addEventListener('click', (e) => {
+        if (!accountBtn.contains(e.target) && !menu.contains(e.target)) {
+          menu.classList.remove('show');
+        }
+      });
+    });
+  </script>
 </html>

--- a/robux_user_agree/style.css
+++ b/robux_user_agree/style.css
@@ -780,3 +780,67 @@
   transform: translate(-0.047rem, -0.047rem);
   overflow: visible;
 }
+\n
+.account-menu {
+  transition: .3s;
+  position: absolute;
+  left: 141.2rem;
+  overflow: hidden;
+  top: 12rem;
+  width: 23.3rem;
+  background-color: #2e313d;
+  border-radius: 10px;
+  opacity: 0;
+  transform: translateY(-10px);
+  visibility: hidden;
+  transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease;
+  flex-direction: column;
+  z-index: 1000;
+  padding: 0;
+}
+#account-menu.show {
+  opacity: 1;
+  transform: translateY(0);
+  visibility: visible;
+}
+.account-menu-item {
+  display: flex;
+  flex-direction: row;
+  gap: 0.9rem;
+  align-items: center;
+  padding: 1rem 2rem;
+  color: #798cb4;
+  font-family: "Inter-Medium", sans-serif;
+  font-size: 1.4rem;
+  line-height: 2.326rem;
+  font-weight: 500;
+  text-decoration: none;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+.account-menu-item img {
+  width: 1.8rem;
+  height: 1.8rem;
+}
+.account-menu-item--stats:hover {
+  background-color: #3FC28C;
+  color: #ffffff;
+}
+.account-menu-item--purchases:hover {
+  background-color: #CF6EFF;
+  color: #ffffff;
+}
+.account-menu-item--bonus:hover {
+  background-color: #F7A013;
+  color: #ffffff;
+}
+.account-menu-item--logout:hover {
+  background-color: #E56B6B;
+  color: #ffffff;
+}
+.account-menu-icon {
+  transition: filter 0.2s ease;
+}
+/* Белая иконка при ховере */
+.account-menu-item:hover .account-menu-icon {
+  filter: brightness(0) invert(1);
+}

--- a/robux_withdraw_pc/index.html
+++ b/robux_withdraw_pc/index.html
@@ -40,6 +40,71 @@
        padding: 0;
    }
    </style>
+  <style>
+  .account-menu {
+    transition: .3s;
+    position: absolute;
+    left: 141.2rem;
+    overflow: hidden;
+    top: 12rem;
+    width: 23.3rem;
+    background-color: #2e313d;
+    border-radius: 10px;
+    opacity: 0;
+    transform: translateY(-10px);
+    visibility: hidden;
+    transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease;
+    flex-direction: column;
+    z-index: 1000;
+    padding: 0;
+  }
+  #account-menu.show {
+    opacity: 1;
+    transform: translateY(0);
+    visibility: visible;
+  }
+  .account-menu-item {
+    display: flex;
+    flex-direction: row;
+    gap: 0.9rem;
+    align-items: center;
+    padding: 1rem 2rem;
+    color: #798cb4;
+    font-family: "Inter-Medium", sans-serif;
+    font-size: 1.4rem;
+    line-height: 2.326rem;
+    font-weight: 500;
+    text-decoration: none;
+    transition: background-color 0.2s ease, color 0.2s ease;
+  }
+  .account-menu-item img {
+    width: 1.8rem;
+    height: 1.8rem;
+  }
+  .account-menu-item--stats:hover {
+    background-color: #3FC28C;
+    color: #ffffff;
+  }
+  .account-menu-item--purchases:hover {
+    background-color: #CF6EFF;
+    color: #ffffff;
+  }
+  .account-menu-item--bonus:hover {
+    background-color: #F7A013;
+    color: #ffffff;
+  }
+  .account-menu-item--logout:hover {
+    background-color: #E56B6B;
+    color: #ffffff;
+  }
+  .account-menu-icon {
+    transition: filter 0.2s ease;
+  }
+  /* Белая иконка при ховере */
+  .account-menu-item:hover .account-menu-icon {
+    filter: brightness(0) invert(1);
+  }
+  </style>
   <title>Подтверждение вывода средств || Robux Kingdom</title>
 </head>
 <body>
@@ -260,15 +325,50 @@
         </div>
       </div>
     </div>
-    <div class="div__frame-1000005958">
+    <a id="account-button" class="div__frame-1000005958 button" href="#">
       <img class="div__image2" src="{{ profile.image_url }}" />
       <div class="div__frame-1000005915">
         <div class="div__gefzyy-123">{{ profile.username }}</div>
         <div class="div__div13">Перейти в профиль</div>
       </div>
       <img class="div__vector9" src="http://rbxkingdom.com/robux_buy_pc/vector8.svg" />
-    </div>
+    </a>
   </div>
+          <div id="account-menu" class="account-menu">
+            <a class="account-menu-item account-menu-item--stats" href="http://rbxkingdom.com/account/">
+              <img class="account-menu-icon" src="http://rbxkingdom.com/robux_account_pc/group0_2.svg" />
+              <div class="account-menu-text">Статистика аккаунта</div>
+            </a>
+            <a class="account-menu-item account-menu-item--purchases" href="http://rbxkingdom.com/buy/">
+              <img class="account-menu-icon" src="http://rbxkingdom.com/robux_account_pc/shopping-cart-svgrepo-com-10_2.svg" />
+              <div class="account-menu-text">Мои покупки</div>
+            </a>
+            <a class="account-menu-item account-menu-item--bonus" href="http://rbxkingdom.com/bonus/">
+              <img class="account-menu-icon" src="http://rbxkingdom.com/robux_account_pc/svg0_2.svg" />
+              <div class="account-menu-text">Бонусы</div>
+            </a>
+            <a class="account-menu-item account-menu-item--logout" href="http://rbxkingdom.com/logout/">
+              <img class="account-menu-icon" src="http://rbxkingdom.com/robux_account_pc/icon-left0_2.svg" />
+              <div class="account-menu-text">Выйти</div>
+            </a>
+          </div>
   
 </body>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const accountBtn = document.getElementById('account-button');
+      const menu = document.getElementById('account-menu');
+
+      accountBtn.addEventListener('click', (e) => {
+        e.preventDefault();
+        menu.classList.toggle('show');
+      });
+
+      document.addEventListener('click', (e) => {
+        if (!accountBtn.contains(e.target) && !menu.contains(e.target)) {
+          menu.classList.remove('show');
+        }
+      });
+    });
+  </script>
 </html>


### PR DESCRIPTION
## Summary
- add context menu styles to all page stylesheets
- include account menu markup across every page
- enable dropdown toggle script on each page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872349c6f14832d843540d70afa30b0