### PR TITLE
Show GIF when no gamepasses

### DIFF
--- a/robux_gamepasses_pc/index.html
+++ b/robux_gamepasses_pc/index.html
@@ -292,7 +292,11 @@ document.addEventListener('DOMContentLoaded', () => {
       </div>
       <div class="game-pass__image-76">
         <div style='font-size: 2rem; color: white; left: 6rem; position: absolute; top: 26.4rem; font-family: "Wix Madefor Display", sans-serif;'>{{ expected_gamepass_price|default_if_none:"" }}</div>
+        {% if has_gamepasses %}
         <img style="height: auto; width: 47rem;" src="http://rbxkingdom.com/robux_gamepasses_pc/check.gif" />
+        {% else %}
+        <img style="height: auto; width: 47rem;" src="http://rbxkingdom.com/robux_head_pc/card-index-dividers-10.gif" />
+        {% endif %}
       </div>
     </div>
     <div class="game-pass__frame-1000002205">


### PR DESCRIPTION
## Summary
- show alternate GIF on the gamepass page if the place has no gamepasses
- provide helper function `any_gamepasses_exist`

## Testing
- `python manage.py check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_687e2069094c832d96830e4407a23756