### PR TITLE
Improve Unfold admin appearance

### DIFF
--- a/main/apps.py
+++ b/main/apps.py
@@ -4,3 +4,4 @@ from django.apps import AppConfig
 class MainConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "main"
+    verbose_name = "Главное приложение"

--- a/main/static/css/styles.css
+++ b/main/static/css/styles.css
@@ -1,0 +1,4 @@
+/* Custom admin tweaks */
+.sidebar-header img {
+    max-height: 40px;
+}

--- a/robuxsite/settings.py
+++ b/robuxsite/settings.py
@@ -59,6 +59,13 @@ UNFOLD = {
     # Принудительная тема: 'light' или 'dark'
     "THEME": "dark",
 
+    # Заголовок и логотип админки
+    "SITE_TITLE": "Robux Kingdom",
+    "SITE_HEADER": "Robux Kingdom",
+    "SITE_SUBHEADER": "Администрирование",
+    "SITE_LOGO": lambda request: static("logo.svg"),
+    "SITE_ICON": lambda request: static("logo.svg"),
+
     # Переопределяем цвета
     "COLORS": {
         # Ваш фирменный жёлтый
@@ -78,7 +85,7 @@ UNFOLD = {
 
     # Подключаем ваш скомпилированный CSS
     "STYLES": [
-        lambda request: static("css/styles.css"),
+        lambda request: static("main/css/styles.css"),
     ],
 }
 
@@ -149,7 +156,7 @@ AUTH_PASSWORD_VALIDATORS = [
 # Internationalization
 # https://docs.djangoproject.com/en/5.2/topics/i18n/
 
-LANGUAGE_CODE = "en-us"
+LANGUAGE_CODE = "ru"
 
 TIME_ZONE = "UTC"
 


### PR DESCRIPTION
## Summary
- set app verbose name in Russian
- configure Unfold admin title, header, and logo
- use Russian as default language
- tweak admin styles

## Testing
- `python manage.py check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688b30697aa4832da3795ed582e69bd8