### PR TITLE
Implement login endpoint and wire main-page popups

### DIFF
--- a/main/templates/index.html
+++ b/main/templates/index.html
@@ -670,8 +670,9 @@
           Введите свой никнейм, чтобы мы нашли ваш аккаунт в системе Roblox
         </div>
         <div class="popup-title">Мой аккаунт</div>
-        <form method="post">
+        <form method="post" action="{% url 'login' %}">
           {% csrf_token %}
+          <input type="hidden" name="next" value="{{ request.path }}">
           <input type="text" name="username" required class="popup-input-container"
             style="padding-left: 2rem; font-size: 4rem; color: white;">
             <div id="user-suggestions" class="user-suggestions"></div>

--- a/main/urls.py
+++ b/main/urls.py
@@ -4,6 +4,7 @@ from .views import (
     BonusView,
     AccountView,
     logout_view,
+    login_view,
     CheckAccountView,
     CheckPlace,
     GamePass,
@@ -25,6 +26,7 @@ from .views import (
 
 urlpatterns = [
     path('', HomeView.as_view(), name='home'),
+    path('login/', login_view, name='login'),
     path('bonus/', BonusView.as_view(), name='bonus'),
     path('account/', AccountView.as_view(), name='account'),
     path('logout/', logout_view, name="logout"),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Django>=5.2
 django-unfold
 requests
+django-cors-headers

--- a/robux_head_pc/index.html
+++ b/robux_head_pc/index.html
@@ -887,8 +887,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
   <div id="login-popup" class="popup">
     <div class="popup-content">
-      <form method="post">
+      <form method="post" action="{% url 'login' %}">
         {% csrf_token %}
+        <input type="hidden" name="next" value="{{ request.path }}">
         <label for="popup-username">Никнейм</label>
         <input id="popup-username" type="text" name="username" required>
         <button type="submit">Войти</button>
@@ -920,8 +921,9 @@ document.addEventListener('DOMContentLoaded', () => {
           Введите свой никнейм, чтобы мы нашли ваш аккаунт в системе Roblox
         </div>
         <div class="popup-title">Мой аккаунт</div>
-        <form method="post">
+        <form method="post" action="{% url 'login' %}">
           {% csrf_token %}
+          <input type="hidden" name="next" value="{{ request.path }}">
           <input type="text" name="username" required class="popup-input-container"
             style="padding-left: 2rem; font-size: 4rem; color: white;">
             <div id="user-suggestions" class="user-suggestions"></div>


### PR DESCRIPTION
## Summary
- add dedicated login_view and reusable login_user helper
- route pop-up login forms in desktop and mobile homepages to new login endpoint
- include django-cors-headers dependency

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688ccd0eb28c832db117cb4da80c4799